### PR TITLE
Skip no-commit-to-branch hook in CI

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -58,6 +58,8 @@ jobs:
       - name: 🏗 Install dependencies
         run: uv sync --locked
       - name: 🚀 Run pre-commit hooks
+        env:
+          SKIP: no-commit-to-branch
         run: uv run prek run --all-files
 
   yamllint:


### PR DESCRIPTION
## Summary

- skip the `no-commit-to-branch` hook in the linting CI job
- keep the hook enabled for local commits

The linting workflow runs `prek run --all-files` on pushes to `main`. After a merge, the GitHub Actions checkout is on `main`, so the local branch-protection hook rejects the CI checkout and makes the workflow fail. Skipping this local-only guard in CI keeps the remaining prek checks active without changing local developer protection.